### PR TITLE
Add options to block manager

### DIFF
--- a/src/__TESTS__/ExampleBlocks/BlogPostContainerBlock/BlogPostContainerBlock.tsx
+++ b/src/__TESTS__/ExampleBlocks/BlogPostContainerBlock/BlogPostContainerBlock.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 
-import { IBlockRegistryOption } from "../../../BlockManager";
+import { IBlockRegistryOption } from "../../../types";
 import { gql, useLazyQuery } from "@apollo/client";
 
 type BlogPost = {

--- a/src/__TESTS__/ExampleBlocks/HeaderHeroBlock/HeaderHeroBlock.tsx
+++ b/src/__TESTS__/ExampleBlocks/HeaderHeroBlock/HeaderHeroBlock.tsx
@@ -1,4 +1,4 @@
-import { IBlockRegistryOption } from "../../../BlockManager";
+import { IBlockRegistryOption } from "../../../types";
 import CmsContent from "../CmsContent/CmsContent";
 import React from "react";
 

--- a/src/__TESTS__/ExampleBlocks/TextBlock.tsx
+++ b/src/__TESTS__/ExampleBlocks/TextBlock.tsx
@@ -1,4 +1,4 @@
-import { IBlockRegistryOption } from "../../BlockManager";
+import { IBlockRegistryOption } from "../../types";
 import CmsContent from "./CmsContent/CmsContent";
 
 export const TextBlockQuery = `

--- a/src/__TESTS__/testRegistry.tsx
+++ b/src/__TESTS__/testRegistry.tsx
@@ -2,7 +2,7 @@ import { HeaderHeroBlockOptions } from "./ExampleBlocks/HeaderHeroBlock/HeaderHe
 import { HeroContainerBlockOptions } from "./ExampleBlocks/HeroContainerBlock/HeroContainerBlock";
 import { TextBlockOptions } from "./ExampleBlocks/TextBlock";
 import { BlogPostContainerBlockOptions } from "./ExampleBlocks/BlogPostContainerBlock/BlogPostContainerBlock";
-import { IBlockRegistryOption } from "../BlockManager";
+import { IBlockRegistryOption } from "../types";
 
 // end of imports
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,9 +3,17 @@ import {
   IBlockManagerProps,
   IBlockComponent,
   IBlockRegistryOption,
-} from "./BlockManager";
+} from "./types";
 
-const BlockManager: React.FC<IBlockManagerProps> = ({ blocks, registry }) => {
+const BlockManager: React.FC<IBlockManagerProps> = ({
+  blocks,
+  registry,
+  options,
+}) => {
+  if (options) {
+    // todo: remove this in the future.
+    console.log(options);
+  }
   // console.log(blocks)
   const getBlockComponent = (
     block: IBlockComponent,

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,7 +10,12 @@ export interface IBlockRegistryOption {
   cols?: number;
 }
 
-interface IBlockManagerProps {
+export interface IBlockOptions {
+  transformer?: "umbraco" | "strapi" | "hygraph";
+}
+
+export interface IBlockManagerProps {
   blocks: IBlockComponent[];
   registry: IBlockRegistryOption[];
+  options?: IBlockOptions;
 }


### PR DESCRIPTION
Add options object to make configuration easier.
Allow users to configure a transform layer to map json to an array of IBlockComponents